### PR TITLE
(SIMP-604) Migrate to simplib and simpcat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,6 +4,7 @@ fixtures:
     augeasproviders_core: "git://github.com/simp/augeasproviders_core"
     augeasproviders_grub: "git://github.com/simp/augeasproviders_grub"
     common              : "git://github.com/simp/pupmod-simp-common"
+    simplib              : "git://github.com/simp/pupmod-simp-simplib"
     concat              : "git://github.com/simp/pupmod-simp-concat"
     functions           : "git://github.com/simp/pupmod-simp-functions"
     iptables            : "git://github.com/simp/pupmod-simp-iptables"

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,5 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-variables_not_enclosed-check
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,71 @@
 ---
 language: ruby
 cache: bundler
+bundler_args: --without development system_tests
+before_install: rm Gemfile.lock || true
 rvm:
-    - 1.8.7
-    - 1.9.3
-    - 2.0.0
-    - 2.2.1
-install: bundle install
+#  - 1.8.7  # bombs out on mime-types
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.1
 script:
     - 'bundle exec rake validate'
     - 'bundle exec rake lint'
     - 'bundle exec rake spec'
+# NOTE: `:environmentpath` was not supported before Puppet 3.5
+env:
+  global:
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
+
 matrix:
-    allow_failures:
-        - rvm: 1.8.7
-        - rvm: 2.2.1
+  fast_finish: true
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: 2.1.0
+    - rvm: 2.2.1
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
+
+  exclude:
+  # Ruby 1.8.7
+  # - Ruby 1.8.7 & Puppet 4.X is impossibru
+
+  # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
+  # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
+  # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
+
+  # Ruby 1.9.3
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 2.7.0"
+
+  # Ruby 2.0.0
+  - rvm: 2.0.0
+    env: PUPPET_VERSION="~> 2.7.0"
+
+  # Ruby 2.1.0
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0"
+
+  # Ruby 2.2.1
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -7,17 +7,38 @@ gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[,
 
 gem_sources.each { |gem_source| source gem_source }
 
+group :test do
+  gem 'rake'
+  gem 'puppet', puppetversion
+  gem 'rspec', '< 3.2.0'
+  gem 'rspec-puppet'
+  gem 'puppetlabs_spec_helper'
+  gem 'metadata-json-lint'
+  gem 'simp-rspec-puppet-facts'
 
-gem 'puppet', puppetversion
-gem 'puppet-lint'
-gem 'puppetlabs_spec_helper'
-gem 'puppet_module_spec_helper'
-gem 'simp-rake-helpers'
+  # simp-rake-helpers does not suport puppet 2.7.X
+  # FIXME: simp-rake-helpers should support Puppet 4.X
+  if (!(['2','4'].include?( "#{ENV['PUPPET_VERSION']}".split('.').first)) &&
+      ("#{ENV['PUPPET_VERSION']}" !~ /~> ?(2|4)/ ? true : false) ) &&
+      # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
+      # TODO: fix upstream deps (parallel in simp-rake-helpers)
+      !( ENV['TRAVIS'] && RUBY_VERSION.sub(/\.\d+$/,'') == '1.8' )
+    gem 'simp-rake-helpers'
+  end
+end
 
-group :debug do
-    gem 'pry'
-    gem 'pry-doc'
-    gem 'rspec'
-    gem 'mocha'
-    gem 'metadata-json-lint'
+group :development do
+  gem 'travis'
+  gem 'travis-lint'
+  gem 'vagrant-wrapper'
+  gem 'puppet-blacksmith'
+  gem 'guard'
+  gem 'guard-rake'
+  gem 'pry'
+  gem 'pry-doc'
+end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,27 +1,68 @@
-#!/usr/bin/rake -T
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/version'
+require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet-lint/tasks/puppet-lint'
 
-# For playing nice with mock
-File.umask(027)
+# These gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
 
-require 'simp/rake/pkg'
+
+# Lint & Syntax exclusions
+exclude_paths = [
+  "bundle/**/*",
+  "pkg/**/*",
+  "dist/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetSyntax.exclude_paths = exclude_paths
+
+# See: https://github.com/rodjek/puppet-lint/pull/397
+Rake::Task[:lint].clear
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = PuppetLint.configuration.ignore_paths
+end
 
 begin
-  require 'puppetlabs_spec_helper/rake_tasks'
+  require 'simp/rake/pkg'
+  Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
+    t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+  end
 rescue LoadError
-  puts "== WARNING: Gem puppetlabs_spec_helper not found, spec tests cannot be run! =="
+  puts "== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =="
 end
 
-# Lint Material
 begin
-  require 'puppet-lint/tasks/puppet-lint'
-
-  PuppetLint.configuration.send("disable_80chars")
-  PuppetLint.configuration.send("disable_variables_not_enclosed")
-  PuppetLint.configuration.send("disable_class_parameter_defaults")
+  require 'simp/rake/beaker'
+  Simp::Rake::Beaker.new( File.dirname( __FILE__ ) )
 rescue LoadError
-  puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
+  # Ignoring this for now since all of these are currently convenience methods.
 end
 
-Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
-  t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
 end
+
+desc "Populate CONTRIBUTORS file"
+task :contributors do
+  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+end
+
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+  :metadata,
+]

--- a/build/pupmod-vnc.spec
+++ b/build/pupmod-vnc.spec
@@ -1,13 +1,14 @@
 Summary: VNC Puppet Module
 Name: pupmod-vnc
 Version: 4.1.0
-Release: 3
+Release: 4
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: pupmod-auditd >= 4.1.0-3
 Requires: pupmod-common >= 4.2.0
+Requires: pupmod-simplib >= 1.0.0-0
 Requires: puppetlabs-stdlib >= 4.1.0-0
 Requires: pupmod-xinetd >= 2.1.0-0
 Requires: puppet >= 3.3.0
@@ -58,6 +59,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-4
+- migration to simplib and simpcat (lib/ only)
+
 * Mon Apr 06 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-3
 - Updated to ensure that a banner is not printed since this breaks many
   clients.

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,49 @@
+{
+  "name":    "simp-vnc",
+  "version": "4.1.0",
+  "author":  "simp",
+  "summary": "Manages VNC",
+  "license": "Apache-2.0",
+  "source":  "https://github.com/simp/pupmod-simp-vnc",
+  "project_page": "https://github.com/simp/pupmod-simp-vnc",
+  "issues_url":   "https://simp-project.atlassian.net",
+  "tags": [ "simp", "vnc" ],
+  "dependencies": [
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-auditd",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-common",
+      "version_requirement": ">= 4.2.0"
+    },
+    {
+      "name": "simp-simplib",
+      "version_requirement": ">= 1.0.0"
+    },
+    {
+      "name": "simp-xinetd",
+      "version_requirement": ">= 2.1.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ]
+}

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -1,9 +1,17 @@
 require 'spec_helper'
 
 describe 'vnc::client' do
+  context  'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      let(:facts) do
+        facts
+      end
 
-  it { should create_class('vnc::client') }
-  it { should compile.with_all_deps }
-  it { should contain_package('tigervnc') }
-
+      context "on #{os}" do
+        it { should create_class('vnc::client') }
+        it { should compile.with_all_deps }
+        it { should contain_package('tigervnc') }
+      end
+    end
+  end
 end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -1,42 +1,46 @@
 require 'spec_helper'
 
 describe 'vnc::server' do
+  context  'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      let(:facts) do
+        facts
+      end
 
-  let(:facts) {{
-    :operatingsystem => 'RedHat',
-    :lsbmajdistrelease => '6'
-  }}
+      context "on #{os}" do
+        it { should create_class('vnc::server') }
+        it { should compile.with_all_deps }
 
-  it { should create_class('vnc::server') }
-  it { should compile.with_all_deps }
+        it { should contain_class('common') }
+        it { should contain_class('xinetd') }
+        it { should contain_class('xwindows') }
 
-  it { should contain_class('common') }
-  it { should contain_class('xinetd') }
-  it { should contain_class('xwindows') }
+        it do
+          should create_vnc__server__create('vnc_standard').with({
+            'port'      => '5901',
+            'geometry'  => '1024x768',
+            'depth'     => '16'
+          })
+        end
+        it do
+          should create_vnc__server__create('vnc_lowres').with({
+            'port'      => '5902',
+            'geometry'  => '800x600',
+            'depth'     => '16'
+          })
+        end
+        it do
+          should create_vnc__server__create('vnc_highres').with({
+            'port'      => '5903',
+            'geometry'  => '1280x1024',
+            'depth'     => '16'
+          })
+        end
 
-  it do
-    should create_vnc__server__create('vnc_standard').with({
-      'port'      => '5901',
-      'geometry'  => '1024x768',
-      'depth'     => '16'
-    })
+        it { should contain_package('tigervnc-server') }
+        it { should create_xwindows__gdm__set('enable_xdmcp') }
+
+      end
+    end
   end
-  it do
-    should create_vnc__server__create('vnc_lowres').with({
-      'port'      => '5902',
-      'geometry'  => '800x600',
-      'depth'     => '16'
-    })
-  end
-  it do
-    should create_vnc__server__create('vnc_highres').with({
-      'port'      => '5903',
-      'geometry'  => '1280x1024',
-      'depth'     => '16'
-    })
-  end
-
-  it { should contain_package('tigervnc-server') }
-  it { should create_xwindows__gdm__set('enable_xdmcp') }
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,9 @@ require 'pathname'
 require 'rspec-puppet'
 require 'puppetlabs_spec_helper/module_spec_helper'
 
+require 'simp/rspec-puppet-facts'
+include Simp::RspecPuppetFacts
+
 # RSpec Material
 
 def mod_site_pp(content)
@@ -28,10 +31,47 @@ default_hiera_config =<<-EOM
 :hierarchy:
   # This is a variable that you can set in your test classes to ensure that the
   # targeted YAML file gets loaded in the fixtures.
-  - "%{spec_title}"
+  - "%{custom_hiera}"
   - "%{module_name}"
   - "default"
 EOM
+
+# This can be used from inside your spec tests to set the testable environment.
+# You can use this to stub out an ENC.
+#
+# Example:
+#
+# context 'in the :foo environment' do
+#   let(:environment){:foo}
+#   ...
+# end
+#
+def set_environment(environment = :production)
+    RSpec.configure { |c| c.default_facts['environment'] = environment.to_s }
+end
+
+# This can be used from inside your spec tests to load custom hieradata within
+# any context.
+#
+# Example:
+#
+# describe 'some::class' do
+#   context 'with version 10' do
+#     let(:hieradata){ "#{class_name}_v10" }
+#     ...
+#   end
+# end
+#
+# Then, create a YAML file at spec/fixtures/hieradata/some__class_v10.yaml.
+#
+# Hiera will use this file as it's base of information stacked on top of
+# 'default.yaml' and <module_name>.yaml per the defaults above.
+#
+# Note: Any colons (:) are replaced with underscores (_) in the class name.
+def set_hieradata(hieradata)
+    RSpec.configure { |c| c.default_facts['custom_hiera'] = hieradata }
+end
+
 
 if not File.directory?(File.join(fixture_path,'hieradata')) then
   FileUtils.mkdir_p(File.join(fixture_path,'hieradata'))
@@ -41,15 +81,14 @@ if not File.directory?(File.join(fixture_path,'modules',module_name)) then
   FileUtils.mkdir_p(File.join(fixture_path,'modules',module_name))
 end
 
-Dir.chdir(File.join(fixture_path,'modules',module_name)) do
-  ['manifests','templates','lib'].each do |tgt|
-    if not File.symlink?(tgt) then
-      FileUtils.ln_sf("../../../../#{tgt}",tgt)
-    end
-  end
-end
-
 RSpec.configure do |c|
+  # ENC-style environment facts
+  c.default_facts = {
+#    :fqdn           => 'production.rspec.test.localdomain',
+    :path           => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+    :concat_basedir => '/tmp'
+  }
+
   c.mock_framework = :rspec
   c.mock_with :mocha
 
@@ -58,35 +97,42 @@ RSpec.configure do |c|
 
   c.hiera_config = File.join(fixture_path,'hieradata','hiera.yaml')
 
-  c.before(:all) do
-# Add fixture lib dirs to LOAD_PATH. Work-around for PUP-3336
-if Puppet.version < "4.0.0"
-  Dir["#{fixture_path}/modules/*/lib"].entries.each do |lib_dir|
-    $LOAD_PATH << lib_dir
-  end
-end
+  if true
+    # Supress useless backtrace noise
+    # START BKGRND
+    backtrace_exclusion_patterns = [
+      /spec_helper/,
+      /gems/
+    ]
 
+    if c.respond_to?(:backtrace_exclusion_patterns)
+      c.backtrace_exclusion_patterns = backtrace_exclusion_patterns
+    elsif c.respond_to?(:backtrace_clean_patterns)
+      c.backtrace_clean_patterns = backtrace_exclusion_patterns
+    end
+    # END BKGRND
+  end
+
+  # create the default hierarchy file
+  c.before(:all) do
     data = YAML.load(default_hiera_config)
-    data[:yaml][:datadir] = File.join(fixture_path, 'hieradata').to_s
+    data[:yaml][:datadir] = File.join(fixture_path, 'hieradata')
+
     File.open(c.hiera_config, 'w') do |f|
       f.write data.to_yaml
     end
-
-    @orig_site_pp = File.join(c.manifest_dir,'site.pp')
-    @orig_site_pp_content = File.read(@orig_site_pp)
   end
 
   c.before(:each) do
-    @spec_global_env_temp = Dir.mktmpdir('simptest')
-    Puppet[:environmentpath] = @spec_global_env_temp
-  end
+    if defined?(environment)
+      set_environment(environment)
+    end
 
-  c.after(:each) do
-    FileUtils.rm_rf(@spec_global_env_temp)
-  end
-
-  c.after(:all) do
-    mod_site_pp(@orig_site_pp_content)
+    if defined?(hieradata)
+      set_hieradata(hieradata.gsub(':','_'))
+    elsif defined?(class_name)
+      set_hieradata(class_name.gsub(':','_'))
+    end
   end
 end
 


### PR DESCRIPTION
Before this commit, common SIMP-related custom functions were been kept
in either `simp-common` or `simp-functions`, and the `concat` function
was provided by the `simp-concat` module.  These functions are now
provides by the `simp-simplib` and `simp-simpcat` modules, respectively.

This update replaces all requirements in the RPM spec file,
metadata.json, or .fixtures.yml to reflect the migration to the new
modules.

SIMP-601 #comment Migrated `pupmod-simp-vnc`.
SIMP-604 #comment Updated `pupmod-simp-vnc`.
