### PR TITLE
Pinning gdm tag to fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,9 @@
 ---
 fixtures:
   repositories:
-    gdm: https://github.com/simp/pupmod-simp-gdm
+    gdm:
+      repo: https://github.com/simp/pupmod-simp-gdm
+      ref: 7.0.3
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
     xinetd: https://github.com/simp/pupmod-simp-xinetd


### PR DESCRIPTION
A recent push to the gdm module broke Travis tests for vnc. This will revert to vnc using the 7.0.3 tag for gdm rather than the latest commit.