### PR TITLE
(SIMP-MAINT) Use Simplib::Port instead of validate_port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Wed Feb 13 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 7.0.1-0
+- Use Simplib::Port data type in lieu of deprecated, simplib
+  Puppet 3 validate_port()
+- Use new Vnc::Geometry data type in lieu of deprecated,
+  stdlib validate_re()
+
 * Thu Nov 01 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.0.0-0
 - Update the contribution guide URL in the README.md
 

--- a/manifests/server/create.pp
+++ b/manifests/server/create.pp
@@ -22,14 +22,11 @@
 # @author https://github.com/simp/pupmod-simp-vnc/graphs/contributors
 #
 define vnc::server::create (
-  Integer $port,
-  String  $geometry            = '800x600',
-  Integer $depth               = 16,
-  Integer $screensaver_timeout = 15
+  Simplib::Port $port,
+  Vnc::Geometry $geometry            = '800x600',
+  Integer       $depth               = 16,
+  Integer       $screensaver_timeout = 15
 ) {
-
-  validate_port($port)
-  validate_re($geometry, '^\d+x\d+$')
 
   include 'xinetd'
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-vnc",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "author": "SIMP Team",
   "summary": "Manages VNC",
   "license": "Apache-2.0",

--- a/spec/type_aliases/vnc_geometry_spec.rb
+++ b/spec/type_aliases/vnc_geometry_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'Vnc::Geometry' do
+  context 'with valid geometry' do
+    it { is_expected.to allow_value('100x200') }
+  end
+
+  context 'with invalid geometry' do
+    it { is_expected.not_to allow_value('100 x 200') }
+    it { is_expected.not_to allow_value(' 100x200') }
+    it { is_expected.not_to allow_value('100x200 ') }
+    it { is_expected.not_to allow_value('100') }
+    it { is_expected.not_to allow_value('100X200') }
+  end
+end

--- a/types/geometry.pp
+++ b/types/geometry.pp
@@ -1,0 +1,1 @@
+type Vnc::Geometry = Pattern['^\d+x\d+$']


### PR DESCRIPTION
- Use Simplib::Port data type in lieu of deprecated, simplib
  Puppet 3 validate_port()
- Use new Vnc::Geometry data type in lieu of deprecated,
  stdlib validate_re()