### PR TITLE
Remove references to archived SIMP modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,6 +8,5 @@ fixtures:
       ref: 'v6.2.0'
     simplib: https://github.com/simp/pupmod-simp-simplib.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
-    xinetd: https://github.com/simp/pupmod-simp-xinetd.git
   symlinks:
     vnc: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,4 +9,3 @@ fixtures:
     simplib: https://github.com/simp/pupmod-simp-simplib.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
     tuned: https://github.com/simp/pupmod-simp-tuned.git
-    xinetd: https://github.com/simp/pupmod-simp-xinetd.git

--- a/metadata.json
+++ b/metadata.json
@@ -23,10 +23,6 @@
     {
       "name": "simp/simplib",
       "version_requirement": ">= 4.9.0 < 6.0.0"
-    },
-    {
-      "name": "simp/xinetd",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -23,10 +23,6 @@
     {
       "name": "simp/simplib",
       "version_requirement": ">= 4.9.0 < 5.0.0"
-    },
-    {
-      "name": "simp/xinetd",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Remove all references to the following archived modules: chkrootkit, hirs_provisioner, incron, network, rkhunter, simp_bolt, simp_ipa, simp_openldap, simp_pki_service, sudosh, tcpwrappers, tpm, xinetd

This includes removal from metadata.json dependencies, .fixtures.yml, Puppetfiles, manifests, spec tests, hiera data, and acceptance tests as applicable.